### PR TITLE
Refine orga PDFs: day headers, room metadata, and overflow safeguards

### DIFF
--- a/backend/app/Http/Controllers/Api/PlanExportController.php
+++ b/backend/app/Http/Controllers/Api/PlanExportController.php
@@ -716,7 +716,7 @@ class PlanExportController extends Controller
         // Determine rows per page depending on multiday events
         $eventDays = DB::table('event')->where('id', $eventId)->value('days');
         $isMultidayEvent = (int) ($eventDays ?? 1) > 1;
-        $maxRowsPerPage = $isMultidayEvent ? 14 : 16; // reduce when date bar is shown
+        $maxRowsPerPage = $isMultidayEvent ? 13 : 16; // reduce when date bar is shown
 
         // PDF erzeugen
         $pdf = match ($type) {
@@ -2278,8 +2278,8 @@ class PlanExportController extends Controller
         // Multiday flag for per-page date bar and row limit adjustments
         $isMultidayEvent = (int) ($event->days ?? 1) > 1;
         // If invoked from a caller that didn't reduce the page size already, do it here
-        if ($isMultidayEvent && (int) $maxRowsPerPage > 14) {
-            $maxRowsPerPage = 14;
+        if ($isMultidayEvent && (int) $maxRowsPerPage > 13) {
+            $maxRowsPerPage = 13;
         }
 
         // Explore zuerst, dann Challenge


### PR DESCRIPTION
## Summary
- fix team PDF day indicators to match room/role behavior by grouping rows per day inside each rendered chunk
- improve room PDF readability and overflow behavior:
  - widen Team column in main room schedule table (Aktivität 30%, Team 40%)
  - switch room preparation team lists to two columns for rooms with more than 18 teams
- add room metadata where needed:
  - moderator top section activities now show `start-end | room`
  - slot assignments now show `<minutes> Min | <room>`
- stabilize shared layout details:
  - footer logos ordered by `event_logo.sort_order`
  - header title kept on one line with fixed center column layout
- reduce multiday row cap from 14 to 13 to prevent referee page overflows

## Test plan
- [ ] Team PDF (2-day): day headers appear at correct positions without forced day page breaks
- [ ] Room PDF: Team column wider and preparation lists split into two columns when >18 teams
- [ ] Moderator PDF: top activities display time and room in both columns
- [ ] Slots PDF: metadata line shows minutes and room
- [ ] Roles PDF (2-day): referee pages no longer overflow with same content density

Made with [Cursor](https://cursor.com)