### PR TITLE
Temporarily disable PDF footer logos for cloud testing

### DIFF
--- a/backend/app/Services/PdfLayoutService.php
+++ b/backend/app/Services/PdfLayoutService.php
@@ -28,8 +28,10 @@ class PdfLayoutService
         // Headerdaten
         $header = $this->buildHeaderData($event);
 
-        // Footerlogos: For QR PDFs, logos are rendered in content area, so pass empty array
-        $footerLogos = $isQrCodePdf ? [] : $this->buildFooterLogos($event->id);
+        // TEMPORARY: Disable footer logos in all PDF layouts.
+        // Cloud servers currently fail on larger PDFs due to image security-policy errors during render.
+        // Keep footer logos empty until infra/server policy issue is resolved.
+        $footerLogos = [];
 
         return View::make('pdf.layout_landscape', [
             'title'       => $title,
@@ -48,8 +50,10 @@ class PdfLayoutService
         // Headerdaten
         $header = $this->buildHeaderData($event);
 
-        // Footerlogos
-        $footerLogos = $this->buildFooterLogos($event->id);
+        // TEMPORARY: Disable footer logos in all PDF layouts.
+        // Cloud servers currently fail on larger PDFs due to image security-policy errors during render.
+        // Keep footer logos empty until infra/server policy issue is resolved.
+        $footerLogos = [];
 
         return View::make('pdf.layout_portrait', [
             'title'       => $title,


### PR DESCRIPTION
## Summary
- temporarily disable footer logo rendering in shared PDF layouts (`renderLayout` and `renderPortraitLayout`)
- keep header rendering unchanged
- add inline comments documenting this as a temporary cloud-stability workaround for current image security-policy render failures

## Test plan
- [ ] On cloud, generate failing PDFs: overview, rooms, roles, teams
- [ ] Confirm these PDFs now render successfully without termination
- [ ] Verify moderator, team-list, and QR/WLAN PDFs still generate as expected
- [ ] Confirm footer logos are absent in affected PDF layouts (temporary behavior)

Made with [Cursor](https://cursor.com)