### PR TITLE
Convert PDF content icons to data URIs for cloud render stability

### DIFF
--- a/backend/resources/views/pdf/content/right_qr.blade.php
+++ b/backend/resources/views/pdf/content/right_qr.blade.php
@@ -1,4 +1,15 @@
 {{-- resources/views/pdf/partials/right_qr.blade.php --}}
+@php
+    $accessibleNoIcon = null;
+    $path = public_path('flow/accessible_no.png');
+    if (is_file($path)) {
+        $mime = mime_content_type($path) ?: 'image/png';
+        $data = @file_get_contents($path);
+        if ($data !== false) {
+            $accessibleNoIcon = 'data:' . $mime . ';base64,' . base64_encode($data);
+        }
+    }
+@endphp
 <td style="width:34%; text-align:center;">
 
     <div style="
@@ -69,8 +80,8 @@
                         <tr>
                             <td valign="top" style="width:33%; padding:4px 8px 4px 6px; vertical-align:top; font-size:12px; color:#444; font-family:sans-serif; white-space:normal; line-height:1.2;">
                                 {{ $roomName }}
-                                @if(!$isAccessible)
-                                    <img src="{{ public_path('flow/accessible_no.png') }}" alt="Nicht barrierefrei" style="height:12px; width:auto; margin-left:4px;">
+                                @if(!$isAccessible && !empty($accessibleNoIcon))
+                                    <img src="{{ $accessibleNoIcon }}" alt="Nicht barrierefrei" style="height:12px; width:auto; margin-left:4px;">
                                 @endif
                             </td>
                             <td valign="top" style="width:67%; padding:4px 6px; vertical-align:top; font-size:12px; color:#444; font-family:sans-serif; white-space:normal; word-wrap:break-word; line-height:1.2;">

--- a/backend/resources/views/pdf/content/role_schedule.blade.php
+++ b/backend/resources/views/pdf/content/role_schedule.blade.php
@@ -1,14 +1,26 @@
 @php
     $icon = null;
     $cleanTitle = $title;
+    $toDataUri = function (string $path): ?string {
+        if (!is_file($path)) {
+            return null;
+        }
+        $mime = mime_content_type($path) ?: 'image/png';
+        $data = @file_get_contents($path);
+        if ($data === false) {
+            return null;
+        }
+        return 'data:' . $mime . ';base64,' . base64_encode($data);
+    };
 
     if (str_contains($title, 'FLL Explore')) {
-        $icon = public_path('flow/fll_explore_h.png');
+        $icon = $toDataUri(public_path('flow/fll_explore_h.png'));
         $cleanTitle = trim(str_replace('FLL Explore', '', $title));
     } elseif (str_contains($title, 'FLL Challenge')) {
-        $icon = public_path('flow/fll_challenge_h.png');
+        $icon = $toDataUri(public_path('flow/fll_challenge_h.png'));
         $cleanTitle = trim(str_replace('FLL Challenge', '', $title));
     }
+    $hourglassIcon = $toDataUri(public_path('flow/hourglass.png'));
 
     // Group rows by day
     $activitiesByDay = [];
@@ -59,8 +71,8 @@
                         @foreach($dayData['rows'] as $i => $row)
                             <tr style="background-color:{{ $i % 2 === 0 ? '#ffffff' : '#f9f9f9' }};">
                                 <td style="text-align:center; padding:4px;">
-                                    @if(!empty($row['is_free']))
-                                        <img src="{{ public_path('flow/hourglass.png') }}" alt="Free interval" style="height:16px; width:auto;">
+                                    @if(!empty($row['is_free']) && !empty($hourglassIcon))
+                                        <img src="{{ $hourglassIcon }}" alt="Free interval" style="height:16px; width:auto;">
                                     @endif
                                 </td>
                                 <td style="padding:5px 8px;">{{ $row['start'] }}</td>

--- a/backend/resources/views/pdf/content/room_schedule.blade.php
+++ b/backend/resources/views/pdf/content/room_schedule.blade.php
@@ -15,6 +15,22 @@ foreach($rows as $row) {
 }
 
 $isMultiDay = count($activitiesByDay) > 1;
+
+$toDataUri = function (string $path): ?string {
+    if (!is_file($path)) {
+        return null;
+    }
+    $mime = mime_content_type($path) ?: 'image/png';
+    $data = @file_get_contents($path);
+    if ($data === false) {
+        return null;
+    }
+    return 'data:' . $mime . ';base64,' . base64_encode($data);
+};
+
+$hourglassIcon = $toDataUri(public_path('flow/hourglass.png'));
+$exploreIcon = $toDataUri(public_path('flow/fll_explore_v.png'));
+$challengeIcon = $toDataUri(public_path('flow/fll_challenge_v.png'));
 @endphp
 
 <h2 style="margin-bottom: 6px; font-size: 22px; font-weight: bold;">
@@ -49,22 +65,22 @@ $isMultiDay = count($activitiesByDay) > 1;
                     @foreach($dayData['rows'] as $i => $row)
                         <tr style="background-color:{{ $i % 2 === 0 ? '#ffffff' : '#f9f9f9' }};">
                             <td style="text-align:center; padding:4px;">
-                                @if(!empty($row['is_free']))
-                                    <img src="{{ public_path('flow/hourglass.png') }}" alt="Free interval" style="height:16px; width:auto;">
+                                @if(!empty($row['is_free']) && !empty($hourglassIcon))
+                                    <img src="{{ $hourglassIcon }}" alt="Free interval" style="height:16px; width:auto;">
                                 @endif
                             </td>
                             <td style="padding:5px 8px;">{{ $row['start'] }}</td>
                             <td style="padding:5px 8px;">{{ $row['end'] }}</td>
                             {{-- Explore Icon --}}
                             <td style="text-align:center; padding:4px;">
-                                @if(!empty($row['is_explore']))
-                                    <img src="{{ public_path('flow/fll_explore_v.png') }}" alt="Explore" style="height:16px;">
+                                @if(!empty($row['is_explore']) && !empty($exploreIcon))
+                                    <img src="{{ $exploreIcon }}" alt="Explore" style="height:16px;">
                                 @endif
                             </td>
                             {{-- Challenge Icon --}}
                             <td style="text-align:center; padding:4px;">
-                                @if(!empty($row['is_challenge']))
-                                    <img src="{{ public_path('flow/fll_challenge_v.png') }}" alt="Challenge" style="height:16px;">
+                                @if(!empty($row['is_challenge']) && !empty($challengeIcon))
+                                    <img src="{{ $challengeIcon }}" alt="Challenge" style="height:16px;">
                                 @endif
                             </td>
                             <td style="padding:5px 8px;">{{ $row['activity'] }}</td>

--- a/backend/resources/views/pdf/content/room_schedule_preparation.blade.php
+++ b/backend/resources/views/pdf/content/room_schedule_preparation.blade.php
@@ -1,3 +1,18 @@
+@php
+    $toDataUri = function (string $path): ?string {
+        if (!is_file($path)) {
+            return null;
+        }
+        $mime = mime_content_type($path) ?: 'image/png';
+        $data = @file_get_contents($path);
+        if ($data === false) {
+            return null;
+        }
+        return 'data:' . $mime . ';base64,' . base64_encode($data);
+    };
+    $exploreIcon = $toDataUri(public_path('flow/fll_explore_v.png'));
+    $challengeIcon = $toDataUri(public_path('flow/fll_challenge_v.png'));
+@endphp
 <h2 style="margin-bottom: 15px; font-size: 22px; font-weight: bold;">
     {{ $room }}
 </h2>
@@ -37,13 +52,13 @@
                                         @endphp
                                         <tr bgcolor="{{ $bgColor }}">
                                             <td style="text-align:center; padding:4px;">
-                                                @if($row['is_explore'])
-                                                    <img src="{{ public_path('flow/fll_explore_v.png') }}" alt="Explore" style="height:16px;">
+                                                @if($row['is_explore'] && !empty($exploreIcon))
+                                                    <img src="{{ $exploreIcon }}" alt="Explore" style="height:16px;">
                                                 @endif
                                             </td>
                                             <td style="text-align:center; padding:4px;">
-                                                @if($row['is_challenge'])
-                                                    <img src="{{ public_path('flow/fll_challenge_v.png') }}" alt="Challenge" style="height:16px;">
+                                                @if($row['is_challenge'] && !empty($challengeIcon))
+                                                    <img src="{{ $challengeIcon }}" alt="Challenge" style="height:16px;">
                                                 @endif
                                             </td>
                                             <td style="padding:5px 8px;">{!! \App\Helpers\PdfHelper::formatTeamNameWithNoshow($row['team_display'] ?? '–', $row['team_is_noshow'] ?? false) !!}</td>
@@ -68,13 +83,13 @@
                                         @endphp
                                         <tr bgcolor="{{ $bgColor }}">
                                             <td style="text-align:center; padding:4px;">
-                                                @if($row['is_explore'])
-                                                    <img src="{{ public_path('flow/fll_explore_v.png') }}" alt="Explore" style="height:16px;">
+                                                @if($row['is_explore'] && !empty($exploreIcon))
+                                                    <img src="{{ $exploreIcon }}" alt="Explore" style="height:16px;">
                                                 @endif
                                             </td>
                                             <td style="text-align:center; padding:4px;">
-                                                @if($row['is_challenge'])
-                                                    <img src="{{ public_path('flow/fll_challenge_v.png') }}" alt="Challenge" style="height:16px;">
+                                                @if($row['is_challenge'] && !empty($challengeIcon))
+                                                    <img src="{{ $challengeIcon }}" alt="Challenge" style="height:16px;">
                                                 @endif
                                             </td>
                                             <td style="padding:5px 8px;">{!! \App\Helpers\PdfHelper::formatTeamNameWithNoshow($row['team_display'] ?? '–', $row['team_is_noshow'] ?? false) !!}</td>
@@ -102,15 +117,15 @@
                             <tr bgcolor="{{ $bgColor }}">
                                 {{-- Explore Icon --}}
                                 <td style="text-align:center; padding:4px;">
-                                    @if($row['is_explore'])
-                                        <img src="{{ public_path('flow/fll_explore_v.png') }}" alt="Explore" style="height:16px;">
+                                    @if($row['is_explore'] && !empty($exploreIcon))
+                                        <img src="{{ $exploreIcon }}" alt="Explore" style="height:16px;">
                                     @endif
                                 </td>
 
                                 {{-- Challenge Icon --}}
                                 <td style="text-align:center; padding:4px;">
-                                    @if($row['is_challenge'])
-                                        <img src="{{ public_path('flow/fll_challenge_v.png') }}" alt="Challenge" style="height:16px;">
+                                    @if($row['is_challenge'] && !empty($challengeIcon))
+                                        <img src="{{ $challengeIcon }}" alt="Challenge" style="height:16px;">
                                     @endif
                                 </td>
 

--- a/backend/resources/views/pdf/content/team_schedule.blade.php
+++ b/backend/resources/views/pdf/content/team_schedule.blade.php
@@ -1,14 +1,26 @@
 @php
     $icon = null;
     $cleanTitle = $team;
+    $toDataUri = function (string $path): ?string {
+        if (!is_file($path)) {
+            return null;
+        }
+        $mime = mime_content_type($path) ?: 'image/png';
+        $data = @file_get_contents($path);
+        if ($data === false) {
+            return null;
+        }
+        return 'data:' . $mime . ';base64,' . base64_encode($data);
+    };
 
     if (str_contains($team, 'FLL Explore')) {
-        $icon = public_path('flow/fll_explore_h.png');
+        $icon = $toDataUri(public_path('flow/fll_explore_h.png'));
         $cleanTitle = trim(str_replace('FLL Explore', '', $team));
     } elseif (str_contains($team, 'FLL Challenge')) {
-        $icon = public_path('flow/fll_challenge_h.png');
+        $icon = $toDataUri(public_path('flow/fll_challenge_h.png'));
         $cleanTitle = trim(str_replace('FLL Challenge', '', $team));
     }
+    $hourglassIcon = $toDataUri(public_path('flow/hourglass.png'));
 
     // Group rows by day (same approach as room/role PDFs)
     $activitiesByDay = [];
@@ -60,8 +72,8 @@
                             @endphp
                             <tr style="background-color:{{ $bgColor }};">
                                 <td style="text-align:center; padding:4px;">
-                                    @if(!empty($row['is_free']))
-                                        <img src="{{ public_path('flow/hourglass.png') }}" alt="Free interval" style="height:16px; width:auto;">
+                                    @if(!empty($row['is_free']) && !empty($hourglassIcon))
+                                        <img src="{{ $hourglassIcon }}" alt="Free interval" style="height:16px; width:auto;">
                                     @endif
                                 </td>
                                 <td style="padding:5px 8px;">{{ $row['start'] }}</td>

--- a/backend/resources/views/pdf/event-overview.blade.php
+++ b/backend/resources/views/pdf/event-overview.blade.php
@@ -117,6 +117,21 @@ foreach($eventsByDay as $dayKey => $dayData) {
         
         $remainingWidth = 90;
         $columnWidth = $remainingWidth / $actualHtmlColumns;
+
+        $toDataUri = function (string $path): ?string {
+            if (!is_file($path)) {
+                return null;
+            }
+            $mime = mime_content_type($path) ?: 'image/png';
+            $data = @file_get_contents($path);
+            if ($data === false) {
+                return null;
+            }
+            return 'data:' . $mime . ';base64,' . base64_encode($data);
+        };
+        $hotHeaderLogo = $toDataUri(public_path('flow/hot.png'));
+        $exploreHeaderLogo = $toDataUri(public_path('flow/fll_explore_h.png'));
+        $challengeHeaderLogo = $toDataUri(public_path('flow/fll_challenge_h.png'));
         
         
         // Check if columns exist to determine merge behavior
@@ -150,13 +165,13 @@ foreach($eventsByDay as $dayKey => $dayData) {
             
             if ($columnName === 'Allgemein') {
                 // Logo only
-                $headerContent = '<img src="' . public_path('flow/hot.png') . '" style="height: 20px; width: auto;">';
+                $headerContent = $hotHeaderLogo ? '<img src="' . $hotHeaderLogo . '" style="height: 20px; width: auto;">' : htmlspecialchars($displayName);
                 $contentHtml .= '
                     <th style="width: ' . $columnWidth . '%; background-color: white; color: ' . $color . '; padding: 4px; border: 1px solid #ddd; font-size: 9px; font-weight: bold; text-align: center;">' . $headerContent . '</th>';
             } elseif ($columnName === 'Allgemein-2') {
                 if ($hasAllgemein2 && $hasExplore) {
                     // Merged cell for Allgemein-2 + Explore
-                    $headerContent = '<img src="' . public_path('flow/fll_explore_h.png') . '" style="height: 20px; width: auto;">';
+                    $headerContent = $exploreHeaderLogo ? '<img src="' . $exploreHeaderLogo . '" style="height: 20px; width: auto;">' : htmlspecialchars($displayName);
                     $contentHtml .= '
                         <th colspan="' . $exploreColumns . '" style="width: ' . $columnWidth . '%; background-color: white; color: ' . $color . '; padding: 4px; border: 1px solid #ddd; font-size: 9px; font-weight: bold; text-align: center;">' . $headerContent . '</th>';
                 } elseif ($hasAllgemein2) {
@@ -168,7 +183,7 @@ foreach($eventsByDay as $dayKey => $dayData) {
             } elseif ($columnName === 'Allgemein-3') {
                 if ($hasAllgemein3 && $challengeColumns > 1) {
                     // Merged cell for Allgemein-3 + Challenge + Robot-Game + Live Challenge
-                    $headerContent = '<img src="' . public_path('flow/fll_challenge_h.png') . '" style="height: 20px; width: auto;">';
+                    $headerContent = $challengeHeaderLogo ? '<img src="' . $challengeHeaderLogo . '" style="height: 20px; width: auto;">' : htmlspecialchars($displayName);
                     $contentHtml .= '
                         <th colspan="' . $challengeColumns . '" style="width: ' . $columnWidth . '%; background-color: white; color: ' . $color . '; padding: 4px; border: 1px solid #ddd; font-size: 9px; font-weight: bold; text-align: center;">' . $headerContent . '</th>';
                 } elseif ($hasAllgemein3) {
@@ -180,14 +195,14 @@ foreach($eventsByDay as $dayKey => $dayData) {
             } elseif ($columnName === 'Explore') {
                 // Explore gets icon only if Allgemein-2 doesn't exist
                 if (!$hasAllgemein2) {
-                    $headerContent = '<img src="' . public_path('flow/fll_explore_h.png') . '" style="height: 20px; width: auto;">';
+                    $headerContent = $exploreHeaderLogo ? '<img src="' . $exploreHeaderLogo . '" style="height: 20px; width: auto;">' : htmlspecialchars($displayName);
                     $contentHtml .= '
                         <th style="width: ' . $columnWidth . '%; background-color: white; color: ' . $color . '; padding: 4px; border: 1px solid #ddd; font-size: 9px; font-weight: bold; text-align: center;">' . $headerContent . '</th>';
                 }
             } elseif ($columnName === 'Challenge') {
                 // Challenge gets icon only if not merged with other columns
                 if (!$hasAllgemein3 && !$hasRobotGame && !$hasLiveChallenge) {
-                    $headerContent = '<img src="' . public_path('flow/fll_challenge_h.png') . '" style="height: 20px; width: auto;">';
+                    $headerContent = $challengeHeaderLogo ? '<img src="' . $challengeHeaderLogo . '" style="height: 20px; width: auto;">' : htmlspecialchars($displayName);
                     $contentHtml .= '
                         <th style="width: ' . $columnWidth . '%; background-color: white; color: ' . $color . '; padding: 4px; border: 1px solid #ddd; font-size: 9px; font-weight: bold; text-align: center;">' . $headerContent . '</th>';
                 }

--- a/backend/resources/views/pdf/slot-assignments.blade.php
+++ b/backend/resources/views/pdf/slot-assignments.blade.php
@@ -20,6 +20,21 @@
     </style>
 </head>
 <body>
+    @php
+        $toDataUri = function (string $path): ?string {
+            if (!is_file($path)) {
+                return null;
+            }
+            $mime = mime_content_type($path) ?: 'image/png';
+            $data = @file_get_contents($path);
+            if ($data === false) {
+                return null;
+            }
+            return 'data:' . $mime . ';base64,' . base64_encode($data);
+        };
+        $exploreIcon = $toDataUri(public_path('flow/fll_explore_v.png'));
+        $challengeIcon = $toDataUri(public_path('flow/fll_challenge_v.png'));
+    @endphp
     @if(empty($slots ?? []))
         <div class="header">
             <h1>{{ $eventName }} – {{ $eventDate }}</h1>
@@ -79,10 +94,10 @@
                                     <tr>
                                         <td>{{ $row['start_time'] }}</td>
                                         <td>
-                                            @if(($row['first_program'] ?? 0) === 2)
-                                                <img src="{{ public_path('flow/fll_explore_v.png') }}" alt="Explore" style="height:14px; width:auto; vertical-align:middle; margin-right:6px;">
-                                            @elseif(($row['first_program'] ?? 0) === 3)
-                                                <img src="{{ public_path('flow/fll_challenge_v.png') }}" alt="Challenge" style="height:14px; width:auto; vertical-align:middle; margin-right:6px;">
+                                            @if(($row['first_program'] ?? 0) === 2 && !empty($exploreIcon))
+                                                <img src="{{ $exploreIcon }}" alt="Explore" style="height:14px; width:auto; vertical-align:middle; margin-right:6px;">
+                                            @elseif(($row['first_program'] ?? 0) === 3 && !empty($challengeIcon))
+                                                <img src="{{ $challengeIcon }}" alt="Challenge" style="height:14px; width:auto; vertical-align:middle; margin-right:6px;">
                                             @endif
                                             {!! \App\Helpers\PdfHelper::formatTeamNameWithNoshow($row['team_label'] ?? '–', $row['team_noshow'] ?? false) !!}
                                         </td>


### PR DESCRIPTION
## Summary
- convert PNG image references in PDF content views from file-path sources (`public_path(...)`) to inline data URIs
- apply this to rooms, roles, teams, room preparation pages, slot assignments, event overview headers, and shared `right_qr` content
- keep visual output unchanged while aligning image-loading behavior with paths that already work on cloud

## Why
Cloud rendering fails on larger PDFs with image security-policy errors in the Dompdf/Imagick image path. This change removes file-path image loading in affected content templates.

## Test plan
- [ ] Generate failing PDFs on cloud: overview, rooms, roles, teams
- [ ] Verify PDFs render without termination
- [ ] Verify icons/logos still appear correctly in tables and headers
- [ ] Verify moderator and QR/WLAN PDFs remain functional

Made with [Cursor](https://cursor.com)