### PR TITLE
Restore footer logos after PDF image path fix

### DIFF
--- a/backend/app/Services/PdfLayoutService.php
+++ b/backend/app/Services/PdfLayoutService.php
@@ -28,10 +28,8 @@ class PdfLayoutService
         // Headerdaten
         $header = $this->buildHeaderData($event);
 
-        // TEMPORARY: Disable footer logos in all PDF layouts.
-        // Cloud servers currently fail on larger PDFs due to image security-policy errors during render.
-        // Keep footer logos empty until infra/server policy issue is resolved.
-        $footerLogos = [];
+        // Footerlogos: For QR PDFs, logos are rendered in content area, so pass empty array
+        $footerLogos = $isQrCodePdf ? [] : $this->buildFooterLogos($event->id);
 
         return View::make('pdf.layout_landscape', [
             'title'       => $title,
@@ -50,10 +48,8 @@ class PdfLayoutService
         // Headerdaten
         $header = $this->buildHeaderData($event);
 
-        // TEMPORARY: Disable footer logos in all PDF layouts.
-        // Cloud servers currently fail on larger PDFs due to image security-policy errors during render.
-        // Keep footer logos empty until infra/server policy issue is resolved.
-        $footerLogos = [];
+        // Footerlogos
+        $footerLogos = $this->buildFooterLogos($event->id);
 
         return View::make('pdf.layout_portrait', [
             'title'       => $title,


### PR DESCRIPTION
## Summary
- restore standard footer logo rendering in `PdfLayoutService` for both portrait and landscape PDFs
- remove temporary footer-logo disable workaround now that cloud-safe image handling is in place
- keep event-logo ordering via `event_logo.sort_order`

## Test plan
- [ ] Generate Overview PDF
- [ ] Generate Rooms PDF
- [ ] Generate Roles PDF
- [ ] Generate Teams PDF
- [ ] Confirm cloud generation succeeds and footer logos render in expected order

Made with [Cursor](https://cursor.com)