### PR TITLE
Increase extra_block name length to 100

### DIFF
--- a/backend/database/migrations/2026_04_13_120000_extend_extra_block_name_length.php
+++ b/backend/database/migrations/2026_04_13_120000_extend_extra_block_name_length.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (! Schema::hasTable('extra_block') || ! Schema::hasColumn('extra_block', 'name')) {
+            return;
+        }
+
+        Schema::table('extra_block', function (Blueprint $table) {
+            $table->string('name', 100)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (! Schema::hasTable('extra_block') || ! Schema::hasColumn('extra_block', 'name')) {
+            return;
+        }
+
+        Schema::table('extra_block', function (Blueprint $table) {
+            $table->string('name', 50)->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration to expand `extra_block.name` from 50 to 100 characters
- keep `name` nullable and include a down migration back to 50
- migration was executed successfully in local environment

## Test plan
- [x] Run `php artisan migrate --path=database/migrations/2026_04_13_120000_extend_extra_block_name_length.php`
- [ ] Create/update an extra block with a name longer than 50 chars
- [ ] Verify existing PDFs/UI still render names correctly

Made with [Cursor](https://cursor.com)