### PR TITLE
Fix LC overrun in Overview and reduce activity label limit to 35

### DIFF
--- a/backend/app/Http/Controllers/Api/PlanExportController.php
+++ b/backend/app/Http/Controllers/Api/PlanExportController.php
@@ -3385,6 +3385,11 @@ class PlanExportController extends Controller
         foreach ($eventOverview as &$event) {
             $event['assigned_column'] = $event['group_overview_plan_column'] ?? 'Allgemein';
 
+            // Normalize legacy naming to keep header/data column matching stable.
+            if ($event['assigned_column'] === 'Live-Challenge') {
+                $event['assigned_column'] = 'Live Challenge';
+            }
+
             // Handle empty strings as well as null
             if (empty($event['assigned_column'])) {
                 $event['assigned_column'] = 'Allgemein';

--- a/backend/app/Http/Controllers/Api/PlanExportController.php
+++ b/backend/app/Http/Controllers/Api/PlanExportController.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\Log;
 
 class PlanExportController extends Controller
 {
-    private const PDF_ACTIVITY_LABEL_MAX_LENGTH = 40;
+    private const PDF_ACTIVITY_LABEL_MAX_LENGTH = 35;
 
     private ActivityFetcherService $activityFetcher;
 


### PR DESCRIPTION
## Summary
- keep truncation logic centralized in `PlanExportController`
- update `PDF_ACTIVITY_LABEL_MAX_LENGTH` from 40 to 35
- apply shorter limit consistently to room, role, and team PDF activity labels

## Test plan
- [ ] Generate Room PDF and verify activity labels truncate consistently
- [ ] Generate Role PDF and verify activity labels truncate consistently
- [ ] Generate Team PDF and verify activity labels truncate consistently

Made with [Cursor](https://cursor.com)