### PR TITLE
Increase default max execution time fallback

### DIFF
--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -136,6 +136,6 @@ return [
     |
     */
 
-    'max_execution_time' => env('MAX_EXECUTION_TIME', 60),
+    'max_execution_time' => env('MAX_EXECUTION_TIME', 300),
 
 ];


### PR DESCRIPTION
## Summary
- update `config/app.php` default fallback for `MAX_EXECUTION_TIME`
- change fallback value from `60` to `300` seconds
- keeps env override behavior unchanged

## Test plan
- [ ] Start app without `MAX_EXECUTION_TIME` set and verify config resolves to 300
- [ ] Set `MAX_EXECUTION_TIME` explicitly and verify env value still takes precedence

Made with [Cursor](https://cursor.com)